### PR TITLE
Replace awscurl with curl

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,7 @@ runs:
       shell: bash
       run: |
         curl \
+          --fail \
           --user "${{ env.AWS_ACCESS_KEY_ID }}":"${{ env.AWS_SECRET_ACCESS_KEY }}" \
           --aws-sigv4 "aws:amz:${{ inputs.region }}:execute-api" \
           -X POST \

--- a/action.yml
+++ b/action.yml
@@ -16,12 +16,6 @@ runs:
   using: composite
 
   steps:
-    - name: Install dependencies for macOS
-      shell: bash
-      if: runner.os == 'macOS'
-      run: |
-        brew install jq
-
     - name: Generate GitHub access token and assign it to environment variable
       shell: bash
       run: |

--- a/action.yml
+++ b/action.yml
@@ -17,24 +17,19 @@ runs:
 
   steps:
     - name: Install dependencies for macOS
-      shell: bash 
+      shell: bash
       if: runner.os == 'macOS'
       run: |
-        brew install awscurl jq
-
-    - name: Install dependencies
-      shell: bash
-      if: runner.os != 'macOS'
-      run: | 
-        pip install awscurl
+        brew install jq
 
     - name: Generate GitHub access token and assign it to environment variable
       shell: bash
       run: |
-         awscurl \
-           --region ${{ inputs.region }} \
-           --service execute-api \
-           -X POST \
-           ${{ inputs.invoke-url }}/configurations/${{ inputs.configuration-name }}/github-access-tokens \
-           | jq -r '"echo \"${{ inputs.configuration-name }}=\(.token)\" >> $GITHUB_ENV"' \
-           | bash
+        curl \
+          --user "${{ env.AWS_ACCESS_KEY_ID }}":"${{ env.AWS_SECRET_ACCESS_KEY }}" \
+          --aws-sigv4 "aws:amz:${{ inputs.region }}:execute-api" \
+          -X POST \
+          -H "x-amz-security-token: ${{ env.AWS_SESSION_TOKEN }}" \
+          ${{ inputs.invoke-url }}/configurations/${{ inputs.configuration-name }}/github-access-tokens \
+          | jq -r '"echo \"${{ inputs.configuration-name }}=\(.token)\" >> $GITHUB_ENV"' \
+          | bash


### PR DESCRIPTION
As `awscurl` is currently producing issues on `macos` GitHub Actions runtime (requests are not properly signed in the latest version `0.33_2` installed via homebrew) we are replacing it with default tooling available in the different runtimes. In version `7.75.0` (see https://curl.se/changes.html) `curl` introduced the `aws-sigv4` parameter which does allow simple signing of requests. Therefore it can be used to sign requests to AWS instead.

Changes:

- replace `awscurl` with `curl` using SigV4 parameter. `awscurl`
- fail `curl` request on non `200` response
- Drop installation of `jq` as this is present anyway and otherwise creates a warning during installation.